### PR TITLE
Ability to read the .git_users.yml in other repositories/directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .DS_Store
-.git_users.yml

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The script will ask you for the name of your new branch. Make sure your input do
 
 #### `pull_request.rb`
 
-This script can be used to handily make new pull requests and to merge pull requests from the command line. The script uses the [`Octokit::Client`](https://octokit.github.io/octokit.rb/Octokit/Client.html) to do this, so make sure you have a `.git_users.yml` file set up in this repository (the file will not be committed to GitHub):
+This script can be used to handily make new pull requests and to merge pull requests from the command line. The script uses the [`Octokit::Client`](https://octokit.github.io/octokit.rb/Octokit/Client.html) to do this, so make sure you have a `~/.scripts_git_users.yml` file set up in this repository (the file will not be committed to GitHub):
 ```
 # first GitHub user
 'github-user Name':

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The script will ask you for the name of your new branch. Make sure your input do
 
 #### `pull_request.rb`
 
-This script can be used to handily make new pull requests and to merge pull requests from the command line. The script uses the [`Octokit::Client`](https://octokit.github.io/octokit.rb/Octokit/Client.html) to do this, so make sure you have a `~/.scripts_git_users.yml` file set up in this repository (the file will not be committed to GitHub):
+This script can be used to handily make new pull requests and to merge pull requests from the command line. The script uses the [`Octokit::Client`](https://octokit.github.io/octokit.rb/Octokit/Client.html) to do this, so make sure you have a `~/.scripts_git_users.yml` file set up in this repository:
 ```
 # first GitHub user
 'github-user Name':

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The script will ask you for the name of your new branch. Make sure your input do
 
 #### `pull_request.rb`
 
-This script can be used to handily make new pull requests and to merge pull requests from the command line. The script uses the [`Octokit::Client`](https://octokit.github.io/octokit.rb/Octokit/Client.html) to do this, so make sure you have a `~/.scripts_git_users.yml` file set up in this repository:
+This script can be used to handily make new pull requests and to merge pull requests from the command line. The script uses the [`Octokit::Client`](https://octokit.github.io/octokit.rb/Octokit/Client.html) to do this, so make sure you have a `~/.scripts_git_users.yml` file set up in the home directory of your computer:
 ```
 # first GitHub user
 'github-user Name':

--- a/octokit_client.rb
+++ b/octokit_client.rb
@@ -16,10 +16,14 @@ class OctokitClient
   end
 
   private def config_file
-    YAML.load_file(github_config_file)
+    YAML.load_file(github_config_file_path)
+  end
+
+  private def github_config_file_path
+    Dir.pwd.scan(/\A\/[\w]*\/[\w]*\//).first << github_config_file
   end
 
   private def github_config_file
-    '.git_users.yml'
+    '.scripts_git_users.yml'
   end
 end


### PR DESCRIPTION
Changes:
* Take the `.git_users.yml` file out of this directory (and remove it from the `.gitignore`)
* Adjust the `octokit_client.rb` file to read the Yaml file out of the computers home directory, instead of from this repo
* Update the README to reflect that change